### PR TITLE
Two handed rifles

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -141,9 +141,26 @@
 
 	if(heavy_weapon)
 		if(user.get_inactive_hand())
-			if(prob(15))
-				if(user.drop_item())
-					user.visible_message("<span class='danger'>[src] flies out of [user]'s hands!</span>", "<span class='userdanger'>[src] kicks out of your grip!</span>")
+			var/kickback = rand(1,100)
+			user << "<span class='userdanger'>[src] kicks around as you fire one handed!</span>"
+			switch(kickback)
+				if(1 to 15) //15% chance
+					if(user.drop_item())
+						user.visible_message("<span class='danger'>[src] flies out of [user]'s hands!</span>", "<span class='userdanger'>[src] kicks out of your hand!</span>")
+				if(16 to 45) //30% chance
+					//var/obj/item/bodypart/headsToSmack = user.get_bodypart(
+					//var/obj/item/bodypart/affecting = H.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
+					if(user.apply_damage(rand(1,10), damagetype = BRUTE, def_zone = "head", blocked = 0))
+						user.visible_message("<span class='danger'>[src] recoils up and smacks [user] in the face!</span>", "<span class='userdanger'>[src] recoils up and smacks you in the face!</span>")
+						user.update_damage_overlays()
+				if(46 to 50) //5% chance
+					if(user.apply_damage(rand(1,10), damagetype = BRUTE, def_zone = "head", blocked = 0))
+						user.Weaken(4)
+						user.visible_message("<span class='danger'>[src] recoils up and smacks [user] in the face, knocking them to the floor!</span>", "<span class='userdanger'>[src] recoils up and smacks you in the face, knocking you to the floor!</span>")
+						user.update_damage_overlays()
+			return
+
+
 
 /obj/item/weapon/gun/emp_act(severity)
 	for(var/obj/O in contents)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -275,6 +275,7 @@
 	mag_load_sound = 'sound/effects/wep_magazines/ar_load.ogg'
 	mag_unload_sound = 'sound/effects/wep_magazines/ar_unload.ogg'
 	chamber_sound = 'sound/effects/wep_magazines/ar_chamber.ogg'
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/assault_rifle/infiltrator
 	name = "infiltrator"
@@ -290,6 +291,7 @@
 	damageS=0
 	rangeG=0
 	fire_sound = 'sound/weapons/Gunshot_large_silenced.ogg'
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/assault_rifle/infiltrator/New()
 	..()
@@ -319,6 +321,7 @@
 	damageA=0
 	damageS=0
 	rangeG=0
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/marksman/New()
 	..()
@@ -333,6 +336,7 @@
 	item_state = "assault_rifle"
 	fire_sound = 'sound/f13weapons/varmint_rifle.ogg'
 	zoomable = FALSE
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/minigun
 	name = "Minigun"
@@ -346,6 +350,7 @@
 	can_suppress = 0
 	burst_size = 3
 	fire_delay = 0.5
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/shotgun/pancor
 	name = "pancor jackhammer"
@@ -357,6 +362,7 @@
 	can_suppress = 0
 	burst_size = 3
 	w_class = 4
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/shotgun/riot
 	name = "riot shotgun"
@@ -369,6 +375,7 @@
 	fire_sound = 'sound/f13weapons/riot_shotgun.ogg'
 	mag_type = /obj/item/ammo_box/magazine/d12g
 	w_class = 4
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/automatic/lsw
 	name = "light support weapon"
@@ -387,3 +394,4 @@
 	mag_unload_sound = 'sound/effects/wep_magazines/ar_unload.ogg'
 	chamber_sound = 'sound/effects/wep_magazines/ar_chamber.ogg'
 	w_class = 5
+	heavy_weapon = 1

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -368,7 +368,7 @@
 	fire_delay = 0
 	pin = /obj/item/device/firing_pin/implant/pindicate
 	action_button_name = null
-	
+
 
 /obj/item/weapon/gun/projectile/automatic/shotgun/bulldog/unrestricted
 	pin = /obj/item/device/firing_pin

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -16,6 +16,7 @@
 	mag_load_sound = null
 	mag_unload_sound = null		//Shotguns have their own procs related to loading, unloading, etc.
 	chamber_sound = null
+	heavy_weapon = 1 //Added by Gomble - Use both yer hams.
 
 /obj/item/weapon/gun/projectile/shotgun/attackby(obj/item/A, mob/user, params)
 	var/num_loaded = magazine.attackby(A, user, params, 1)
@@ -167,6 +168,7 @@
 	sawn_desc = "Omar's coming!"
 	unique_rename = 1
 	unique_reskin = 1
+	heavy_weapon = 1 //Should this be rehashed to shotgun class?
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/New()
 	..()
@@ -238,6 +240,7 @@
 	origin_tech = "combat=2;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/mad
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/revolver/single_shotgun
 	name = "single shotgun"
@@ -250,6 +253,7 @@
 	origin_tech = "combat=2;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/revolver/zipgun
 	name = "zipgun"
@@ -286,6 +290,7 @@
 	sawn_desc = "I'm just here for the gasoline."
 	unique_rename = 0
 	unique_reskin = 0
+	heavy_weapon = 1
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
@@ -363,6 +368,7 @@
 	fire_delay = 0
 	pin = /obj/item/device/firing_pin/implant/pindicate
 	action_button_name = null
+	
 
 /obj/item/weapon/gun/projectile/automatic/shotgun/bulldog/unrestricted
 	pin = /obj/item/device/firing_pin


### PR DESCRIPTION
Adds heavy_weapons = 1 to several guns that are ideally two handed
Adds effects to heavy_weapons to damage, drop and/or stun based on a roll. 50/50 chance something bad will happen
Adds message when unsafely using a heavy weapon so the user knows the weapon is a 2H. Alert type might be too large though, gets spammy.