### PR TITLE
Dynamite crafting

### DIFF
--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/grenade/syndieminibomb
-	desc = "A syndicate manufactured explosive used to sow destruction and chaos"
-	name = "syndicate minibomb"
+	desc = "A stick of dynamite. The merchant of death's making bank. Light the fuse and toss."
+	name = "dynamite"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
 	item_state = "flashbang"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -58,6 +58,15 @@
 	parts = list(/obj/item/weapon/reagent_containers/food/drinks/bottle = 1)
 	time = 40
 	category = CAT_WEAPON
+	
+/datum/table_recipe/dynamite
+	name = "Dynamite"
+	result = /obj/item/weapon/grenade/syndieminibomb
+	reqs = list(/datum/reagent/blackpowder = 50,
+				/obj/item/stack/sheet/gekkonhide = 1,
+				/obj/item/stack/sheet/metal = 5)
+	time = 60
+	category = CAT_WEAPON
 
 /datum/table_recipe/stunprod
 	name = "Stunprod"


### PR DESCRIPTION
**Boom Boom 2: Electric Boomaloo**

Allows you to craft dynamite from 50 black powder (beaker's worth), 5 metal, and 1 gekkon skin.

Also changes all syndie minibombs to all be renamed to dynamite, with appropriate description. 
(The ones in the legion camp are just renamed in mapping.)

This won't possibly go wrong, nope.