### PR TITLE
Drug overhaul

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -107,7 +107,9 @@
 	var/dammod = 0
 	var/mob/living/carbon/human/humanUser = user
 	if (istype(humanUser) && humanUser.dna && humanUser.dna.species && humanUser.dna.species.id=="bigmutant")
-		dammod = 15
+		dammod = dammod+15
+	if (user.reagents.has_reagent("psycho"))
+		dammod = dammod+20
 	// the attacked_by code varies among species
 	return dna.species.spec_attacked_by(I,user,def_zone,affecting,hit_area,src.a_intent,target_limb,target_area,src, dammod)
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -326,3 +326,217 @@
 		M.adjustOxyLoss(1)
 	..()
 	return
+
+/datum/reagent/drug/psycho
+	name = "Psycho fluid"
+	id = "psycho"
+	description = "Makes the user hit harder and shrug off slight stuns, but causes slight brain damage and carries a risk of addiction."
+	reagent_state = LIQUID
+	color = "#FF0000" // it's red as fuck
+	overdose_threshold = 30
+	addiction_threshold = 15
+
+/datum/reagent/drug/psycho/on_mob_life(mob/living/M)
+	var/high_message = pick("<br><font color='#FF0000'><b>FUCKING KILL!</b></font>", "<br><font color='#FF0000'><b>RAAAAR!</b></font>", "<br><font color='#FF0000'><b>BRING IT!</b></font>")
+	if(prob(5))
+		M << "<span class='notice'>[high_message]</span>"
+	M.AdjustParalysis(-0.5)
+	M.AdjustStunned(-0.5)
+	M.AdjustWeakened(-0.5)
+	M.adjustStaminaLoss(-1)
+	M.adjustBrainLoss(0.25)
+	M.hallucination += 5
+	return
+
+/datum/reagent/drug/psycho/overdose_process(mob/living/M)
+	M.hallucination += 20
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 8, i++)
+			step(M, pick(cardinal))
+	if(prob(20))
+		M.emote(pick("twitch","drool","laugh"))
+	if(prob(33))
+		var/obj/item/I = M.get_active_hand()
+		if(I)
+			M.drop_item()
+	M.adjustBrainLoss(10)
+	..()
+	return
+
+/datum/reagent/drug/psycho/addiction_act_stage1(mob/living/M)
+	M.hallucination += 10
+	M.Jitter(5)
+	M.adjustBrainLoss(10)
+	if(prob(20))
+		M.emote(pick("twitch","drool","laugh"))
+	..()
+	return
+/datum/reagent/drug/psycho/addiction_act_stage2(mob/living/M)
+	M.hallucination += 20
+	M.Jitter(10)
+	M.Dizzy(10)
+	M.adjustBrainLoss(10)
+	if(prob(30))
+		M.emote(pick("twitch","drool","laugh"))
+	..()
+	return
+/datum/reagent/drug/psycho/addiction_act_stage3(mob/living/M)
+	M.hallucination += 30
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 2, i++)
+			step(M, pick(cardinal))
+	M.Jitter(15)
+	M.Dizzy(15)
+	M.adjustBrainLoss(10)
+	if(prob(40))
+		M.emote(pick("twitch","drool","laugh"))
+	..()
+	return
+/datum/reagent/drug/psycho/addiction_act_stage4(mob/living/carbon/human/M)
+	M.hallucination += 40
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 4, i++)
+			step(M, pick(cardinal))
+	M.Jitter(50)
+	M.Dizzy(50)
+	M.adjustToxLoss(5)
+	M.adjustBrainLoss(10)
+	if(prob(50))
+		M.emote(pick("twitch","drool","laugh"))
+	..()
+	return
+
+/datum/reagent/drug/turbo
+	name = "Turbo fluid"
+	id = "turbo"
+	description = "Makes the user perceive time slower, heightening their reflexes and movements. Basically, it makes you fast. Carries a high risk of addiction."
+	reagent_state = LIQUID
+	color = "#E5E5FF"
+	overdose_threshold = 30
+	addiction_threshold = 15
+
+/datum/reagent/drug/turbo/on_mob_life(mob/living/M)
+	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.")
+	if(prob(5))
+		M << "<span class='notice'>[high_message]</span>"
+	M.status_flags |= GOTTAGOREALLYFAST
+	M.Jitter(2)
+	M.adjustBrainLoss(0.25)
+	if(prob(5))
+		M.emote(pick("twitch", "shiver"))
+	..()
+	return
+
+/datum/reagent/drug/turbo/overdose_process(mob/living/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 4, i++)
+			step(M, pick(cardinal))
+	if(prob(20))
+		M.emote("laugh")
+	if(prob(33))
+		M.visible_message("<span class='danger'>[M]'s hands flip out and flail everywhere!</span>")
+		var/obj/item/I = M.get_active_hand()
+		if(I)
+			M.drop_item()
+	..()
+	M.adjustToxLoss(5)
+	return
+
+/datum/reagent/drug/turbo/addiction_act_stage1(mob/living/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 4, i++)
+			step(M, pick(cardinal))
+	M.Jitter(5)
+	if(prob(20))
+		M.emote(pick("twitch","shake","groan"))
+	..()
+	return
+/datum/reagent/drug/turbo/addiction_act_stage2(mob/living/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 8, i++)
+			step(M, pick(cardinal))
+	M.Jitter(10)
+	M.Dizzy(10)
+	if(prob(30))
+		M.emote(pick("twitch","shake","groan"))
+	..()
+	return
+/datum/reagent/drug/turbo/addiction_act_stage3(mob/living/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 10, i++)
+			step(M, pick(cardinal))
+	M.Jitter(15)
+	M.Dizzy(15)
+	M.adjustToxLoss(2.5)
+	if(prob(40))
+		M.emote(pick("twitch","shake","groan"))
+	..()
+	return
+/datum/reagent/drug/turbo/addiction_act_stage4(mob/living/carbon/human/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 20, i++)
+			step(M, pick(cardinal))
+	M.Jitter(20)
+	M.Dizzy(20)
+	M.adjustToxLoss(5)
+	if(prob(50))
+		M.emote(pick("twitch","shake","groan"))
+	..()
+	return
+
+/datum/reagent/drug/jet
+	name = "Jet fluid"
+	id = "jet"
+	description = "Induces a short, but intense high that'll make you go faster. Carries a high risk of addiction."
+	reagent_state = LIQUID
+	color = "#A52A2A"
+	overdose_threshold = 20
+	addiction_threshold = 15
+
+/datum/reagent/drug/jet/on_mob_life(mob/living/M)
+	var/high_message = pick("You feel amazing.", "You feel like you haven't got a care in the world.", "You see pretty lights.")
+	if(prob(10))
+		M << "<span class='notice'>[high_message]</span>"
+	if(prob(7))
+		M.emote(pick("drool","moan","giggle","laugh"))
+	M.druggy = max(M.druggy, 15)
+	M.status_flags |= GOTTAGOFAST
+	..()
+	return
+
+/datum/reagent/drug/jet/overdose_start(mob/living/M)
+	M << "<span class='userdanger'>Bad trip! Bad trip!</span>"
+
+/datum/reagent/drug/jet/overdose_process(mob/living/M)
+	if(prob(20))
+		M.emote("twitch","moan")
+	M.Jitter(5)
+	M.hallucination += 5
+	M.adjustBrainLoss(0.25)
+	M.adjustToxLoss(5)
+	return
+
+/datum/reagent/drug/jet/addiction_act_stage1(mob/living/M)
+	M.adjustToxLoss(1)
+	..()
+	return
+/datum/reagent/drug/jet/addiction_act_stage2(mob/living/M)
+	M.adjustToxLoss(2)
+	..()
+	return
+/datum/reagent/drug/jet/addiction_act_stage3(mob/living/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 4, i++)
+			step(M, pick(cardinal))
+	M.adjustBrainLoss(0.5)
+	M.adjustToxLoss(3)
+	..()
+	return
+/datum/reagent/drug/jet/addiction_act_stage4(mob/living/carbon/human/M)
+	if(M.canmove && !istype(M.loc, /atom/movable))
+		for(var/i = 0, i < 8, i++)
+			step(M, pick(cardinal))
+	M.adjustBrainLoss(1)
+	M.adjustToxLoss(4)
+	..()
+	return

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1087,16 +1087,22 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = 5
+	if(M.health < M.maxHealth)
+		M.status_flags |= IGNORESLOWDOWN
+	else
+		M.hallucination += 5
 	M.adjustBruteLoss(-0.50*REM)
 	M.adjustFireLoss(-0.50*REM)
-	M.AdjustStunned(-2)
+	M.AdjustParalysis(-5)
+	M.AdjustStunned(-5)
+	M.AdjustWeakened(-5)
+	M.adjustStaminaLoss(-15)
 	..()
 
-/datum/reagent/medicine/medx/reaction_mob(mob/living/M, method=INJECT, reac_volume, show_message = 1)
+/datum/reagent/medicine/medx/reaction_mob(mob/living/M, method=PATCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
-		if(method==INJECT)
-			if(show_message)
-				M << "<span class>Your senses start to numb through out your body...</span>" //It's a painkiller, after all
+		if(show_message)
+			M << pick("You feel <b>FUCKING INVINCIBLE!</b>.", "You feel your senses numbing.", "You feel like you can push it to the limit.") //It's a painkiller, after all
 	..()
 
 /datum/reagent/medicine/medx/on_mob_delete(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1087,10 +1087,9 @@ datum/reagent/medicine/super_stimpak/on_mob_life(mob/living/M)
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = 5
-	if(M.health < M.maxHealth)
-		M.status_flags |= IGNORESLOWDOWN
-	else
+	if(M.health = M.maxHealth)
 		M.hallucination += 5
+	M.status_flags |= IGNORESLOWDOWN
 	M.adjustBruteLoss(-0.50*REM)
 	M.adjustFireLoss(-0.50*REM)
 	M.AdjustParalysis(-5)

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -42,7 +42,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/jet
 	name = "Jet"
 	desc = "Jet is a highly addictive drug first synthesized by Myron. It is extracted from brahmin dung fumes and administered via an inhaler."
-	list_reagents = list("stimulants" = 30, "crank" = 10)
+	list_reagents = list("jet" = 10)
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_15"
 	icon_state = "jet"
@@ -50,7 +50,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/psycho
 	name = "Psycho"
 	desc = "Psycho will increase damage resistance, allowing subjects to survive hits more easily."
-	list_reagents = list("methamphetamine" = 10, "epinephrine" = 20, "inacusiate" = 5, "oculine" = 5)
+	list_reagents = list("psycho" = 10)
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_15"
 	icon_state = "psycho"
@@ -58,7 +58,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/medx
 	name = "Mex-X"
 	desc = "Med-X is a potent opiate analgesic that binds to opioid receptors in the brain and central nervous system, reducing the perception of pain as well as the emotional response to pain. Essentially, it is a painkiller delivered by a hypodermic needle."
-	list_reagents = list("methamphetamine" = 10, "krokodil" = 10, "styptic_powder" = 10, "silver_sulfadiazine" = 10)
+	list_reagents = list("medx" = 10)
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_15"
 	icon_state = "medx"
@@ -66,7 +66,7 @@
 /obj/item/weapon/reagent_containers/pill/patch/turbo
 	name = "Turbo"
 	desc = "Turbo appears as an inhaler of Jet hastily duct-taped to a can of 'HairStylez-brand hair spray. The effect of turbo is a brief slowdown of the surroundings (time goes at about 35% of its original speed), including everything from your enemies' movements, to projectile speeds (your own projectile speed included), and even the duration of the drug itself. However, you are not slowed down yourself - your own movement speed and fire rate will remain the same."
-	list_reagents = list("stimulants" = 10, "methamphetamine" = 10, "crank" = 10)
+	list_reagents = list("turbo" = 10)
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "turbo"
 	item_state = "turbo"


### PR DESCRIPTION
Overhauls the drugs and gives them unique effects related to their NV counterparts.

Psycho - grants a flat melee damage boost of 20, slightly resists stuns
MedX - Highly resists any stun, removes damage slowdown, slightly heals
Turbo - Turn into a blue hedgehog.
Jet - See some pretty lights, turn into a slightly slower blue hedgehog.

All injectors give 10 units of their respective chemical.