### PR TITLE
Add Stimpaks to SmartFridge Whitelist

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/smartfridge.dm
+++ b/code/modules/food&drinks/kitchen machinery/smartfridge.dm
@@ -360,6 +360,8 @@
 		return 0
 	if(!istype(O,/obj/item/weapon/reagent_containers))
 		return 0
+	if(istype(O,/obj/item/weapon/reagent_containers/stimpak))
+		return 1
 	if(istype(O,/obj/item/weapon/reagent_containers/pill)) // empty pill prank ok
 		return 1
 	if(!O.reagents || !O.reagents.reagent_list.len) // other empty containers not accepted


### PR DESCRIPTION
You can now throw all your extra stimpaks into a SmartFridge for safe keeping. Whoo!