### PR TITLE
Craftable First-Aid Kits

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -199,6 +199,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 	new/datum/stack_recipe("folder", /obj/item/weapon/folder), \
 	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
+	new/datum/stack_recipe("first-aid kit", /obj/item/weapon/storage/box/firstaid), \
 )
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -826,3 +826,8 @@
 	new /obj/item/ammo_casing/shotgun/ion(src)
 	new /obj/item/ammo_casing/shotgun/ion(src)
 
+/obj/item/weapon/storage/box/firstaid
+	name = "first-aid kit"
+	desc = "A folded cardboard box for holding medical supplies."
+	icon_state = "firstaid_2"
+	item_state = "firstaid"


### PR DESCRIPTION
Adds an empty first-aid kit to the list of items craftable with cardboard, which inherits being foldable.

Highly recommend adding stacks of cardboard sheets to the Sunnydale Tech Shop, the Den Storage Room, and the Hospital's Janitor Closet.