### PR TITLE
enables suicide

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,4 +1,4 @@
-/mob/var/suiciding = 0
+/mob/var/suiciding = 1
 
 /mob/living/carbon/human/verb/suicide()
 	set hidden = 1


### PR DESCRIPTION
this may not actually be how you enable suicide but its a effort

you can just ghost and respawn, this gives more options for how you die.

suicide is more rp inclined than "he's blankly staring into space"

you can also shoot yourself in the mouth with any firearm and die accordingly.