### PR TITLE
Enables extraction of black powder from shotgun shells.

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -305,6 +305,15 @@
 	time = 8
 	category = CAT_AMMO
 
+/datum/table_recipe/blackpowder_extraction_buckshot
+	name = "Shotgun Shell Black Powder Extraction"
+	result = /obj/item/weapon/reagent_containers/syringe/blackpowder
+	reqs = list(/obj/item/weapon/reagent_containers/syringe = 1,
+			/obj/item/ammo_casing/shotgun = 1)
+	tools = list()
+	time = 5
+	category = CAT_AMMO
+
 /*/datum/table_recipe/laserslug
 	name = "Laser Slug Shell"
 	result = /obj/item/ammo_casing/shotgun/laserslug
@@ -730,4 +739,3 @@
 	time = 120
 	show = 0
 	category = CAT_ARMOR
-

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -247,3 +247,10 @@
 	amount_per_transfer_from_this = 1
 	volume = 1
 	list_reagents = list("mulligan" = 1)
+	
+/obj/item/weapon/reagent_containers/syringe/blackpowder
+	name = "Blackpowder syringe"
+	desc = "A syringe filled with extracted blackpowder."
+	amount_per_transfer_from_this = 1
+	volume = 10
+	list_reagents = list("blackpowder" = 10)


### PR DESCRIPTION
Gives 10 black powder in a syringe from a shotgun shell, requires a syringe. 

Didn't do this for the other bullets as you could just recycle the magazine and print more bullets, allowing infinitely recyclable black powder production. 